### PR TITLE
fix(session): prevent ubuntu garbage collection of php session

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -90,12 +90,14 @@ function login($level) {
       unset($_SESSION['table_prefix']);
       unset($_SESSION['user_id']);
       unset($_SESSION['platoon_id']);
+      session_unset();
       session_destroy();
       return 0;
     } elseif ($alt == "login") {
       if (empty($_POST['anvandarnamn']) || empty($_POST['losenord'])) {
         $_SESSION['inloggad'] = 0;
         $_SESSION['level'] = "0";
+        session_unset();
         session_destroy();
         return 0;
       }

--- a/session.php
+++ b/session.php
@@ -1,7 +1,12 @@
 <?php
-ini_set('session.gc_maxlifetime', 24 * 60 * 60);
+$cookie_lifetime = 24 * 60 * 60;
+ini_set('session.cookie_lifetime', $cookie_lifetime);
 ini_set('session.cookie_secure', 1);
-session_start(['cookie_lifetime' => 24 * 60 * 60]);
+ini_set('session.gc_maxlifetime', $cookie_lifetime);
+ini_set('session.gc_probability', 1);
+ini_set('session.gc_divisor', 100);
+ini_set('session.save_path', "/tmp");
+session_start();
 
 if (!array_key_exists('last_activity', $_SESSION) || time() - $_SESSION['last_activity'] > 30 * 60) {
   session_regenerate_id(true);

--- a/session.php
+++ b/session.php
@@ -1,6 +1,8 @@
 <?php
 $cookie_lifetime = 24 * 60 * 60;
 ini_set('session.cookie_lifetime', $cookie_lifetime);
+ini_set('session.cookie_httponly', 1);
+ini_set('session.cookie_samesite', "Strict");
 ini_set('session.cookie_secure', 1);
 ini_set('session.gc_maxlifetime', $cookie_lifetime);
 ini_set('session.gc_probability', 1);


### PR DESCRIPTION
Changes:
- `ini_set('session.gc_probability', 1);` & `ini_set('session.gc_divisor', 100);` sets the probability of garbage collection to 1/100
- `ini_set('session.save_path', "/tmp");` sets the session save directory to somewhere else than where Ubuntu garbage collects

Session tests:
- iOS, Safari, tue 19:00-16:00 fri, the cookie gets extended but also doesn’t seem to timeout after 24h inactivity.
- MacOs, Chrome, wed 08:00-18:00 fri
- 

Can't seem to find the session files on the server 🤔 weird, maybe lack of rights?
`find / -name "sess_*"`